### PR TITLE
requireTls should enable TLS

### DIFF
--- a/src/main/java/org/subethamail/smtp/server/SMTPServer.java
+++ b/src/main/java/org/subethamail/smtp/server/SMTPServer.java
@@ -359,6 +359,9 @@ public final class SMTPServer implements SSLSocketCreator {
          */
         public Builder requireTLS(boolean value) {
             this.requireTLS = value;
+            if (value) {
+                enableTLS = true;
+            }
             return this;
         }
 


### PR DESCRIPTION
See #1.

In the SMTPServer builder, to ensure that the EHLO command lists STARTTLS as an option, instead of having to call

```java
SMTPServer.port(PORT)
    .requireTLS()
    .enableTLS()
```
we should be able to call:

```java
SMTPServer.port(PORT)
    .requireTLS()
```

