### PR TITLE
Added MessageContext knowledge to authentication

### DIFF
--- a/src/main/java/org/subethamail/smtp/AuthenticationHandler.java
+++ b/src/main/java/org/subethamail/smtp/AuthenticationHandler.java
@@ -32,9 +32,10 @@ public interface AuthenticationHandler
 	 *
 	 * @return <code>empty</code> if the authentication process is finished, otherwise a string to hand back to the client.
 	 * @param clientInput The client's input, eg "AUTH PLAIN dGVzdAB0ZXN0ADEyMzQ="
+	 * @param context The current message context
 	 * @throws org.subethamail.smtp.RejectException if authentication fails.
 	 */
-	Optional<String> auth(String clientInput) throws RejectException;
+	Optional<String> auth(String clientInput, MessageContext context) throws RejectException;
 
 	/**
 	 * If the authentication process was successful, this returns the identity

--- a/src/main/java/org/subethamail/smtp/auth/LoginAuthenticationHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/auth/LoginAuthenticationHandlerFactory.java
@@ -8,6 +8,7 @@ import java.util.StringTokenizer;
 
 import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.smtp.AuthenticationHandlerFactory;
+import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.RejectException;
 import org.subethamail.smtp.internal.util.TextUtils;
 
@@ -64,7 +65,7 @@ public final class LoginAuthenticationHandlerFactory implements AuthenticationHa
 		private String username;
 
 		@Override
-		public Optional<String> auth(String clientInput) throws RejectException
+		public Optional<String> auth(String clientInput, MessageContext context) throws RejectException
 		{
 			StringTokenizer stk = new StringTokenizer(clientInput);
 			String token = stk.nextToken();
@@ -124,7 +125,7 @@ public final class LoginAuthenticationHandlerFactory implements AuthenticationHa
 			String password = TextUtils.getStringUtf8(decoded);
 			try
 			{
-				LoginAuthenticationHandlerFactory.this.helper.login(this.username, password);
+				LoginAuthenticationHandlerFactory.this.helper.login(this.username, password, context);
 			}
 			catch (LoginFailedException lfe)
 			{

--- a/src/main/java/org/subethamail/smtp/auth/MultipleAuthenticationHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/auth/MultipleAuthenticationHandlerFactory.java
@@ -11,6 +11,7 @@ import java.util.StringTokenizer;
 
 import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.smtp.AuthenticationHandlerFactory;
+import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.RejectException;
 
 /**
@@ -76,7 +77,7 @@ public class MultipleAuthenticationHandlerFactory implements AuthenticationHandl
 
 		/* */
 		@Override
-        public Optional<String> auth(String clientInput) throws RejectException
+        public Optional<String> auth(String clientInput, MessageContext context) throws RejectException
 		{
 			if (this.active == null)
 			{
@@ -95,7 +96,7 @@ public class MultipleAuthenticationHandlerFactory implements AuthenticationHandl
 				this.active = fact.create();
 			}
 
-			return this.active.auth(clientInput);
+			return this.active.auth(clientInput, context);
 		}
 
 		/* */

--- a/src/main/java/org/subethamail/smtp/auth/PlainAuthenticationHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/auth/PlainAuthenticationHandlerFactory.java
@@ -10,6 +10,7 @@ import java.util.StringTokenizer;
 
 import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.smtp.AuthenticationHandlerFactory;
+import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.RejectException;
 
 /**
@@ -57,7 +58,7 @@ public final class PlainAuthenticationHandlerFactory implements AuthenticationHa
 
 		/* */
 		@Override
-        public Optional<String> auth(String clientInput) throws RejectException
+        public Optional<String> auth(String clientInput, MessageContext context) throws RejectException
 		{
 			StringTokenizer stk = new StringTokenizer(clientInput);
 			String secret = stk.nextToken();
@@ -126,7 +127,7 @@ public final class PlainAuthenticationHandlerFactory implements AuthenticationHa
 			this.password = passwd;
 			try
 			{
-				PlainAuthenticationHandlerFactory.this.helper.login(this.username.toString(), this.password);
+				PlainAuthenticationHandlerFactory.this.helper.login(this.username.toString(), this.password, context);
 			}
 			catch (LoginFailedException lfe)
 			{

--- a/src/main/java/org/subethamail/smtp/auth/UsernamePasswordValidator.java
+++ b/src/main/java/org/subethamail/smtp/auth/UsernamePasswordValidator.java
@@ -1,5 +1,7 @@
 package org.subethamail.smtp.auth;
 
+import org.subethamail.smtp.MessageContext;
+
 /**
  * Use this when your authentication scheme uses a username and a password.
  *
@@ -7,5 +9,5 @@ package org.subethamail.smtp.auth;
  */
 public interface UsernamePasswordValidator
 {
-	void login(final String username, final String password) throws LoginFailedException;
+	void login(final String username, final String password, MessageContext context) throws LoginFailedException;
 }

--- a/src/main/java/org/subethamail/smtp/internal/command/AuthCommand.java
+++ b/src/main/java/org/subethamail/smtp/internal/command/AuthCommand.java
@@ -75,7 +75,7 @@ public final class AuthCommand extends BaseCommand
 			// The authentication process may require a series of challenge-responses
 			CRLFTerminatedReader reader = sess.getReader();
 
-			Optional<String> response = authHandler.auth(commandString);
+			Optional<String> response = authHandler.auth(commandString, sess);
 			if (response.isPresent())
 			{
 				// challenge-response iteration
@@ -85,7 +85,8 @@ public final class AuthCommand extends BaseCommand
 			while (response.isPresent())
 			{
 				String clientInput = reader.readLine();
-				if (clientInput.trim().equals(AUTH_CANCEL_COMMAND))
+				// clientInput == null -> reached EOF, client abruptly closed?
+				if (clientInput == null || clientInput.trim().equals(AUTH_CANCEL_COMMAND))
 				{
 					// RFC 2554 explicitly states this:
 					sess.sendResponse("501 Authentication canceled by client.");
@@ -93,7 +94,7 @@ public final class AuthCommand extends BaseCommand
 				}
 				else
 				{
-					response = authHandler.auth(clientInput);
+					response = authHandler.auth(clientInput, sess);
 					if (response.isPresent())
 					{
 						// challenge-response iteration

--- a/src/test/java/org/subethamail/smtp/StartTLSFullTest.java
+++ b/src/test/java/org/subethamail/smtp/StartTLSFullTest.java
@@ -111,7 +111,7 @@ public class StartTLSFullTest {
     }
 
     private static AuthenticationHandlerFactory createAuthenticationHandlerFactory() {
-        return new PlainAuthenticationHandlerFactory((username, password) -> {
+        return new PlainAuthenticationHandlerFactory((username, password, context) -> {
             if (!username.equals("me"))
                 throw new LoginFailedException();
         });

--- a/src/test/java/org/subethamail/smtp/command/AuthTest.java
+++ b/src/test/java/org/subethamail/smtp/command/AuthTest.java
@@ -2,6 +2,7 @@ package org.subethamail.smtp.command;
 
 import java.util.Base64;
 
+import org.subethamail.smtp.MessageContext
 import org.subethamail.smtp.auth.EasyAuthenticationHandlerFactory;
 import org.subethamail.smtp.auth.LoginFailedException;
 import org.subethamail.smtp.auth.UsernamePasswordValidator;
@@ -24,7 +25,7 @@ public class AuthTest extends ServerTestCase {
 
     class RequiredUsernamePasswordValidator implements UsernamePasswordValidator {
         @Override
-        public void login(String username, String password) throws LoginFailedException {
+        public void login(String username, String password, MessageContext context) throws LoginFailedException {
             if (!username.equals(REQUIRED_USERNAME) || !password.equals(REQUIRED_PASSWORD)) {
                 throw new LoginFailedException();
             }

--- a/src/test/java/org/subethamail/smtp/command/AuthTest.java
+++ b/src/test/java/org/subethamail/smtp/command/AuthTest.java
@@ -2,7 +2,7 @@ package org.subethamail.smtp.command;
 
 import java.util.Base64;
 
-import org.subethamail.smtp.MessageContext
+import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.auth.EasyAuthenticationHandlerFactory;
 import org.subethamail.smtp.auth.LoginFailedException;
 import org.subethamail.smtp.auth.UsernamePasswordValidator;

--- a/src/test/java/org/subethamail/smtp/server/RequireAuthTest.java
+++ b/src/test/java/org/subethamail/smtp/server/RequireAuthTest.java
@@ -2,6 +2,7 @@ package org.subethamail.smtp.server;
 
 import java.util.Base64;
 
+import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.auth.EasyAuthenticationHandlerFactory;
 import org.subethamail.smtp.auth.LoginFailedException;
 import org.subethamail.smtp.auth.UsernamePasswordValidator;
@@ -22,7 +23,7 @@ public class RequireAuthTest extends ServerTestCase {
 
     class RequiredUsernamePasswordValidator implements UsernamePasswordValidator {
         @Override
-        public void login(String username, String password) throws LoginFailedException {
+        public void login(String username, String password, MessageContext context) throws LoginFailedException {
             if (!username.equals(REQUIRED_USERNAME) || !password.equals(REQUIRED_PASSWORD)) {
                 throw new LoginFailedException();
             }


### PR DESCRIPTION
Pushed down MessageContext knowledge to Authentication mechanisms.
Knowning data from MessageContext is useful and sometimes needed to properly handle custom auth mechanism.

This patch breaks public interfaces. If not acceptable I can change it to support older interface and older custom implementations using default interface methods (but it will neel Java8 compatibility... BTW Java8 itself is EOL)