### PR TITLE
Add custom success return on data command

### DIFF
--- a/src/main/java/org/subethamail/smtp/MessageHandler.java
+++ b/src/main/java/org/subethamail/smtp/MessageHandler.java
@@ -65,7 +65,7 @@ public interface MessageHandler
 	 * 			data stream will be valid only for the duration of the call.
 	 * @return custom success message withou response code like
 	 * 			'OK message received' or {@code null} if return
-	 * 			message shouldm't be customized.
+	 * 			message shouldn't be customized.
 	 *
 	 * @throws RejectException if at any point the data should be rejected.
 	 * @throws DropConnectionException if the connection should be dropped

--- a/src/main/java/org/subethamail/smtp/MessageHandler.java
+++ b/src/main/java/org/subethamail/smtp/MessageHandler.java
@@ -63,7 +63,7 @@ public interface MessageHandler
 	 *
 	 * @param data will be the smtp data stream, stripped of any extra '.' chars. The
 	 * 			data stream will be valid only for the duration of the call.
-	 * @return custom success message withou response code like
+	 * @return custom success message without response code like
 	 * 			'OK message received' or {@code null} if return
 	 * 			message shouldn't be customized.
 	 *

--- a/src/main/java/org/subethamail/smtp/MessageHandler.java
+++ b/src/main/java/org/subethamail/smtp/MessageHandler.java
@@ -61,8 +61,11 @@ public interface MessageHandler
 	 * Note: If you do not read all the data, it will be read for you
 	 * after this method completes.
 	 *
-	 * @param data will be the smtp data stream, stripped of any extra '.' chars.  The
+	 * @param data will be the smtp data stream, stripped of any extra '.' chars. The
 	 * 			data stream will be valid only for the duration of the call.
+	 * @return custom success message withou response code like
+	 * 			'OK message received' or {@code null} if return
+	 * 			message shouldm't be customized.
 	 *
 	 * @throws RejectException if at any point the data should be rejected.
 	 * @throws DropConnectionException if the connection should be dropped
@@ -70,7 +73,7 @@ public interface MessageHandler
 	 *         An error will be reported to the client.
 	 * @throws IOException if there is an IO error reading the input data.
 	 */
-	void data(InputStream data) throws RejectException, TooMuchDataException, IOException;
+	String data(InputStream data) throws RejectException, TooMuchDataException, IOException;
 
 	/**
 	 * Called after all other methods are completed.  Note that this method

--- a/src/main/java/org/subethamail/smtp/examples/BasicSMTPServer.java
+++ b/src/main/java/org/subethamail/smtp/examples/BasicSMTPServer.java
@@ -47,11 +47,12 @@ public final class BasicSMTPServer {
             }
 
             @Override
-            public void data(InputStream data) throws IOException {
+            public String data(InputStream data) throws IOException {
                 System.out.println("MAIL DATA");
                 System.out.println("= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =");
                 System.out.println(this.convertStreamToString(data));
                 System.out.println("= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =");
+                return null;
             }
 
             @Override

--- a/src/main/java/org/subethamail/smtp/helper/BasicMessageHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/helper/BasicMessageHandlerFactory.java
@@ -54,7 +54,7 @@ public class BasicMessageHandlerFactory implements MessageHandlerFactory {
         }
 
         @Override
-        public void data(InputStream is) throws RejectException, TooMuchDataException, IOException {
+        public String data(InputStream is) throws RejectException, TooMuchDataException, IOException {
             try {
                 byte[] bytes = readAndClose(is, maxMessageSize);
 
@@ -67,6 +67,8 @@ public class BasicMessageHandlerFactory implements MessageHandlerFactory {
                     throw new RejectException("recipient not set");
                 }
                 listener.messageArrived(context, from, recipient, bytes);
+
+                return null;
             } catch (RuntimeException e) {
                 throw new RejectException("message could not be accepted: " + e.getMessage());
             }

--- a/src/main/java/org/subethamail/smtp/helper/SimpleMessageListenerAdapter.java
+++ b/src/main/java/org/subethamail/smtp/helper/SimpleMessageListenerAdapter.java
@@ -131,7 +131,7 @@ public final class SimpleMessageListenerAdapter implements MessageHandlerFactory
         }
 
         @Override
-        public void data(InputStream data) throws TooMuchDataException, IOException {
+        public String data(InputStream data) throws TooMuchDataException, IOException {
             if (this.deliveries.size() == 1) {
                 Delivery delivery = this.deliveries.get(0);
                 delivery.getListener().deliver(this.from, delivery.getRecipient(), data);
@@ -152,6 +152,7 @@ public final class SimpleMessageListenerAdapter implements MessageHandlerFactory
                     dfos.close();
                 }
             }
+            return null;
         }
 
         @Override

--- a/src/main/java/org/subethamail/smtp/helper/SmarterMessageListenerAdapter.java
+++ b/src/main/java/org/subethamail/smtp/helper/SmarterMessageListenerAdapter.java
@@ -110,7 +110,7 @@ public class SmarterMessageListenerAdapter implements MessageHandlerFactory {
         }
 
         @Override
-        public void data(InputStream data) throws TooMuchDataException, IOException {
+        public String data(InputStream data) throws TooMuchDataException, IOException {
             if (this.deliveries.size() == 1) {
                 this.deliveries.get(0).deliver(data);
             } else {
@@ -130,6 +130,7 @@ public class SmarterMessageListenerAdapter implements MessageHandlerFactory {
                     dfos.close();
                 }
             }
+            return null;
         }
 
         @Override

--- a/src/main/java/org/subethamail/smtp/internal/Constants.java
+++ b/src/main/java/org/subethamail/smtp/internal/Constants.java
@@ -11,4 +11,11 @@ public final class Constants {
 
     public static final Charset SMTP_CHARSET = StandardCharsets.US_ASCII;
 
+    /**
+     *  Maximum total length of a command line as <a 
+     *  href="https://tools.ietf.org/html/rfc5321#section-4.5.3.1.4> RFC5321
+     *  Sections 4.5.3.1.4 and 4.5.3.1.5</a>
+     */
+    public static final int SMTP_MAX_LINE_LEN = 512;
+
 }

--- a/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
+++ b/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
@@ -74,7 +74,7 @@ public final class DataCommand extends BaseCommand {
         if (dataMessage!= null) {
             sess.sendResponse(SMTPResponseHelper.buildResponse("250", dataMessage));
         } else {
-            sess.sendResponse("250 OK");
+            sess.sendResponse("250 Ok");
         }
         sess.resetMailTransaction();
     }

--- a/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
+++ b/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
@@ -10,6 +10,7 @@ import org.subethamail.smtp.RejectException;
 import org.subethamail.smtp.internal.io.DotTerminatedInputStream;
 import org.subethamail.smtp.internal.io.DotUnstuffingInputStream;
 import org.subethamail.smtp.internal.io.ReceivedHeaderStream;
+import org.subethamail.smtp.internal.util.SMTPResponseHelper;
 import org.subethamail.smtp.internal.server.BaseCommand;
 import org.subethamail.smtp.server.SMTPServer;
 import org.subethamail.smtp.server.Session;
@@ -52,8 +53,9 @@ public final class DataCommand extends BaseCommand {
                     sess.getSingleRecipient());
         }
 
+        String dataMessage = null;
         try {
-            sess.getMessageHandler().data(stream);
+            dataMessage = sess.getMessageHandler().data(stream);
 
             // Just in case the handler didn't consume all the data, we might as
             // well suck it up so it doesn't pollute further exchanges. This
@@ -61,6 +63,7 @@ public final class DataCommand extends BaseCommand {
             // of the contract that we might as well relax.
             while (stream.read() != -1)
                 ;
+
         } catch (DropConnectionException ex) {
             throw ex; // Propagate this
         } catch (RejectException ex) {
@@ -68,7 +71,11 @@ public final class DataCommand extends BaseCommand {
             return;
         }
 
-        sess.sendResponse("250 Ok");
+        if (dataMessage!= null) {
+            sess.sendResponse(SMTPResponseHelper.buildResponse("250", dataMessage));
+        } else {
+            sess.sendResponse("250 OK");
+        }
         sess.resetMailTransaction();
     }
 }

--- a/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
@@ -6,7 +6,7 @@ import org.subethamail.smtp.internal.Constants;
 /**
  * @author Diego Salvi
  */
-public class SMTPResponseHelper {
+public final class SMTPResponseHelper {
 
     private SMTPResponseHelper() {
         // prevent instantiation

--- a/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
@@ -1,0 +1,119 @@
+package org.subethamail.smtp.internal.util;
+
+import org.subethamail.smtp.internal.Constants;
+
+/**
+ * @author Diego Salvi
+ */
+public class SMTPResponseHelper {
+
+    private SMTPResponseHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * @return a valid command response checking for allowed maximum line length and handling multiline
+     *         response formatting.
+     */
+    public static String buildResponse(String code, CharSequence response) {
+
+        /* No a real code check, here we just need to verify that is a 3 digit code */
+        if (code.length() != 3) {
+            throw new IllegalArgumentException("Invalid SMTP response code " + code);
+        }
+
+        final int len = response.length();
+
+        /*
+         * Perform a response size evaluation just to avoid too many array copies.
+         *
+         * Constants.SMTP_MAX_LINE_LEN - 6 is the useful line len without 3 digit code, ' ' or '-' and
+         * trailing \r\n
+         */
+        final int evaluatedLen = ((len / (Constants.SMTP_MAX_LINE_LEN - 6)) + 1) * Constants.SMTP_MAX_LINE_LEN;
+        final StringBuilder result = new StringBuilder(evaluatedLen);
+
+        int lineLen = 4;
+
+        boolean flushLine = false;
+
+        int lastch = -1;
+
+        char[] line = new char[Constants.SMTP_MAX_LINE_LEN];
+
+        /* Setup "continuation" line header */
+        line[0] = code.charAt(0);
+        line[1] = code.charAt(1);
+        line[2] = code.charAt(2);
+        line[3] = '-';
+
+        for(int i = 0; i < len; ++i) {
+
+            char ch = response.charAt(i);
+
+            switch(ch) {
+                case '\r':
+
+                    if (lastch != '\n') {
+                        flushLine = true;
+                    }
+
+                    break;
+
+                case '\n':
+
+                    if (lastch != '\r') {
+                        flushLine = true;
+                    }
+
+                    break;
+
+                default:
+                    line[lineLen++] = ch;
+            }
+
+            lastch = ch;
+
+            /* Max len minus 2 char (sequence \r\n) */
+            if ( lineLen == Constants.SMTP_MAX_LINE_LEN - 2 || flushLine || i == len - 1 ) {
+
+                flushLine = false;
+
+                if ( i != len - 1 ) {
+
+                    /* This isn't the last row */
+
+                    line[lineLen++] = '\r';
+                    line[lineLen++] = '\n';
+                } else {
+                    /* Last row, replace heading 'NNN-' with 'NNN ' */
+                    line[3] = ' ';
+                }
+
+                result.append(line,0,lineLen);
+
+                lineLen = 4;
+            }
+
+        }
+
+        return result.toString();
+
+    }
+
+    /**
+     * @return a valid command response checking for allowed maximum line length and handling multiline
+     *         response formatting.
+     */
+    public static String buildResponse(int code, CharSequence response) {
+
+        /* No a real code check, here we just need to verify that is a 3 digit code */
+        if (code < 100 || code > 999) {
+            throw new IllegalArgumentException("Invalid SMTP response code " + code);
+        }
+
+        return buildResponse(Integer.toString(code), response);
+
+    }
+
+}

--- a/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/SMTPResponseHelper.java
@@ -1,5 +1,6 @@
 package org.subethamail.smtp.internal.util;
 
+import com.github.davidmoten.guavamini.Preconditions;
 import org.subethamail.smtp.internal.Constants;
 
 /**
@@ -17,10 +18,8 @@ public class SMTPResponseHelper {
      */
     public static String buildResponse(String code, CharSequence response) {
 
-        /* No a real code check, here we just need to verify that is a 3 digit code */
-        if (code.length() != 3) {
-            throw new IllegalArgumentException("Invalid SMTP response code " + code);
-        }
+        /* Not a real code check, here we just need to verify that is a 3 digit code */
+        Preconditions.checkArgument(code.length() == 3, "Invalid SMTP response code " + code);
 
         final int len = response.length();
 
@@ -108,9 +107,7 @@ public class SMTPResponseHelper {
     public static String buildResponse(int code, CharSequence response) {
 
         /* No a real code check, here we just need to verify that is a 3 digit code */
-        if (code < 100 || code > 999) {
-            throw new IllegalArgumentException("Invalid SMTP response code " + code);
-        }
+        Preconditions.checkArgument(code > 99 && code < 1000, "Invalid SMTP response code " + code);
 
         return buildResponse(Integer.toString(code), response);
 

--- a/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
+++ b/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
@@ -49,7 +49,8 @@ public class SmartClientTest {
                     }
 
                     @Override
-                    public void data(InputStream data) throws RejectException, TooMuchDataException, IOException {
+                    public String data(InputStream data) throws RejectException, TooMuchDataException, IOException {
+                        return null;
                     }
 
                     @Override

--- a/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
+++ b/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
@@ -8,6 +8,18 @@ import org.subethamail.smtp.internal.util.SMTPResponseHelper;
 
 public class SMTPResponseHelperTest {
 
+    @Test(expected = IllegalArgumentException.class)
+    public void tooShortCode() {
+        SMTPResponseHelper.buildResponse("25", "short");
+        SMTPResponseHelper.buildResponse(25, "short");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooLongCode() {
+        SMTPResponseHelper.buildResponse("2525", "long");
+        SMTPResponseHelper.buildResponse(2525, "long");
+    }
+
     @Test
     public void shortReponse() {
         assertEquals("250 short", SMTPResponseHelper.buildResponse("250", "short"));

--- a/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
+++ b/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
@@ -1,0 +1,47 @@
+package org.subethamail.smtp.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.subethamail.smtp.internal.Constants;
+import org.subethamail.smtp.internal.util.SMTPResponseHelper;
+
+public class SMTPResponseHelperTest {
+
+    @Test
+    public void shortReponse() {
+        assertEquals("250 short", SMTPResponseHelper.buildResponse("250", "short"));
+    }
+
+    @Test
+    public void longReponse() {
+        final int usefulLen = Constants.SMTP_MAX_LINE_LEN - 6;
+        /* Just one character more than useful line len */
+        final int longResponseLen = usefulLen + 1;
+        final StringBuilder builder = new StringBuilder(longResponseLen);
+        for(int i = 0; i < longResponseLen; ++i) {
+            builder.append(i % 10);
+        }
+        final String longResponse = builder.toString();
+
+
+        final StringBuilder expectedBuilder = new StringBuilder();
+        expectedBuilder.append("250-")
+            .append(longResponse.subSequence(0, usefulLen))
+            .append("\r\n")
+            .append("250 ")
+            .append(longResponse.subSequence(usefulLen, longResponse.length()));
+
+        final String expected = expectedBuilder.toString();
+
+        assertEquals(expected, SMTPResponseHelper.buildResponse("250", longResponse));
+    }
+
+    @Test
+    public void withReturns() {
+        assertEquals("250-one\r\n250 two", SMTPResponseHelper.buildResponse("250", "one\r\ntwo"));
+        assertEquals("250-one\r\n250 two", SMTPResponseHelper.buildResponse("250", "one\n\rtwo"));
+        assertEquals("250-one\r\n250 two", SMTPResponseHelper.buildResponse("250", "one\ntwo"));
+        assertEquals("250-one\r\n250 two", SMTPResponseHelper.buildResponse("250", "one\rtwo"));
+    }
+}

--- a/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
+++ b/src/test/java/org/subethamail/smtp/util/SMTPResponseHelperTest.java
@@ -2,11 +2,17 @@ package org.subethamail.smtp.util;
 
 import static org.junit.Assert.assertEquals;
 
+import com.github.davidmoten.junit.Asserts;
 import org.junit.Test;
 import org.subethamail.smtp.internal.Constants;
 import org.subethamail.smtp.internal.util.SMTPResponseHelper;
 
 public class SMTPResponseHelperTest {
+
+    @Test
+    public void isUtilityClass() {
+        Asserts.assertIsUtilityClass(SMTPResponseHelper.class);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void tooShortCode() {


### PR DESCRIPTION
Added the capability to return a custom message as data result different from "250 OK" (Example: return "250 OK. Message equeued as xxxx").

This patch breaks public interfaces. If not acceptable I can change it to support older interface and older custom implementations using default interface methods (but it will neel Java8 compatibility... BTW Java8 itself is EOL)