### PR TITLE
Disabled stacktrace generation for RejectException, closes #11

### DIFF
--- a/src/main/java/org/subethamail/smtp/RejectException.java
+++ b/src/main/java/org/subethamail/smtp/RejectException.java
@@ -12,21 +12,24 @@ package org.subethamail.smtp;
 @SuppressWarnings("serial")
 public class RejectException extends Exception
 {
-	int code;
+	public static final int DEFAULT_CODE = 554;
+	public static final String DEFAULT_MESSAGE = "Transaction failed";
+
+	final int code;
 
 	public RejectException()
 	{
-		this("Transaction failed");
+		this(DEFAULT_MESSAGE);
 	}
 
 	public RejectException(String message)
 	{
-		this(554, message);
+		this(DEFAULT_CODE, message);
 	}
 
 	public RejectException(int code, String message)
 	{
-		super(message);
+		super(message, null, true, false);
 
 		this.code = code;
 	}

--- a/src/test/java/org/subethamail/smtp/RejectExceptionTest.java
+++ b/src/test/java/org/subethamail/smtp/RejectExceptionTest.java
@@ -1,0 +1,55 @@
+package org.subethamail.smtp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * This class tests {@link RejectException} behaviours.
+ *
+ * @author Diego Salvi
+ */
+public class RejectExceptionTest {
+
+    /** Ensure no stacktraces are generated for RejectException */
+    @Test
+    public void noStacktrace() {
+
+        checkEmptyExceptionStackTrace(new RejectException());
+        checkEmptyExceptionStackTrace(new RejectException("message"));
+        checkEmptyExceptionStackTrace(new RejectException(510,"message"));
+
+    }
+
+    /** Ensure right status code returns */
+    @Test
+    public void code() {
+
+        assertEquals(500, new RejectException(500, "message").getCode());
+        assertEquals(RejectException.DEFAULT_CODE, new RejectException("message").getCode());
+        assertEquals(RejectException.DEFAULT_CODE, new RejectException().getCode());
+
+    }
+
+    /** Ensure right error response returns */
+    @Test
+    public void errorResponse() {
+
+        assertEquals("500 message", new RejectException(500, "message").getErrorResponse());
+        assertEquals(RejectException.DEFAULT_CODE + " message", new RejectException("message").getErrorResponse());
+        assertEquals(RejectException.DEFAULT_CODE + " " + RejectException.DEFAULT_MESSAGE,
+                new RejectException().getErrorResponse());
+
+    }
+
+    /** Utility method to check for empty stacktraces */
+    private static final void checkEmptyExceptionStackTrace(RejectException e) {
+
+        final StackTraceElement[] stacktrace = e.getStackTrace();
+
+        assertNotNull(stacktrace);
+        assertEquals(0,stacktrace.length);
+    }
+
+}


### PR DESCRIPTION
* Disable stacktrace generation for RejectException (such exception is always catched and used to generate error messages on protocol)
* added some tests
* added final modifier to code (package visibility and never accesse directly)
