### PR TITLE
Upgrade to Jakarta Mail 1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
             <version>1.6.4</version>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
     <dependencies>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.1</version>
+            <artifactId>jakarta.mail</artifactId>
+            <version>1.6.4</version>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>


### PR DESCRIPTION
Upgrade to [Jakarta Mail](https://eclipse-ee4j.github.io/mail/) 1.6.4. Jakarte EE is the renamed Java EE which Oracle contributed to the open source community. It uses the same class names as [Java Mail](https://java.net/projects/javamail/pages/Home) in the implementation. All tests succeeds.