### PR TITLE
EmailUtils (issue #17)

### DIFF
--- a/src/main/java/org/subethamail/smtp/internal/util/EmailUtils.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/EmailUtils.java
@@ -39,7 +39,7 @@ public final class EmailUtils {
     public static String extractEmailAddress(String args, int offset) {
         String address = args.substring(offset).trim();
         if (address.indexOf('<') == 0) {
-            address = address.substring(1, address.indexOf('>'));
+            address = address.substring(1, address.lastIndexOf('>'));
             // spaces within the <> are also possible, Postfix apparently
             // trims these away:
             return address.trim();

--- a/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
+++ b/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
@@ -1,12 +1,12 @@
 package org.subethamail.smtp.util;
 
-import static org.junit.Assert.assertEquals;
-
+import com.github.davidmoten.junit.Asserts;
 import org.junit.Assert;
 import org.junit.Test;
 import org.subethamail.smtp.internal.util.EmailUtils;
 
-import com.github.davidmoten.junit.Asserts;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class EmailUtilsTest {
 
@@ -28,25 +28,37 @@ public class EmailUtilsTest {
     @Test
     public void testExtract() {
         assertEquals("anyone2@anywhere.com",
-                EmailUtils.extractEmailAddress("TO:<anyone2@anywhere.com>", 3));
+            extractAndValidate("TO:<anyone2@anywhere.com>", 3));
     }
 
     @Test
     public void testExtractWithNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
         assertEquals("test@example.com",
-                EmailUtils.extractEmailAddress("FROM: test@example.com", 5));
+            extractAndValidate("FROM: test@example.com", 5));
     }
 
     @Test
     public void testExtractWithNoLessThanSymbolAtStartOfEmailAndNoPrecedingSpace() {
         assertEquals("test@example.com",
-                EmailUtils.extractEmailAddress("FROM:test@example.com", 5));
+            extractAndValidate("FROM:test@example.com", 5));
     }
 
-    
     @Test
     public void testExtractWithNoLessThanSymbolAtStartOfEmailAndSIZECommand() {
         assertEquals("test@example.com",
-                EmailUtils.extractEmailAddress("FROM:test@example.com SIZE=1000", 5));
+            extractAndValidate("FROM:test@example.com SIZE=1000", 5));
+    }
+
+    @Test
+    public void testExtractWithEmbeddedPersonalName() {
+        // see https://github.com/davidmoten/subethasmtp/issues/17
+        assertEquals("Foo Bar <foobar@example.com>",
+            extractAndValidate("FROM:<Foo Bar <foobar@example.com>>", 5));
+    }
+
+    private static String extractAndValidate(String args, int offset) {
+        String address = EmailUtils.extractEmailAddress(args, offset);
+        assertTrue(EmailUtils.isValidEmailAddress(address));
+        return address;
     }
 }


### PR DESCRIPTION
- EmailUtils: added support for personal name inside `MAIL FROM:<...>` (issue #17)
- EmailUtilsTest: added test case for the above, and updated the other test cases of `extractEmailAddress` to check that the parsed address is valid

_(Note: the imports in EmailUtilsTest were automatically rearranged by IntelliJ IDEA; feel free to rearrange them again as you see fit)_