### PR TITLE
Add MessageContext.getSessionId as new default method

### DIFF
--- a/src/main/java/org/subethamail/smtp/MessageContext.java
+++ b/src/main/java/org/subethamail/smtp/MessageContext.java
@@ -32,10 +32,14 @@ public interface MessageContext
 	 */
 	SocketAddress getRemoteAddress();
 	
-	// TODO to properly associate information gathered and set at session creation
-	// we should be able to unequivocally associate each message with the session. 
-	// To that end we should add a `String getSessionId()` method to this interface.
-
+	/**
+	 * Returns the unique id of the session associated with this message. 
+	 */
+	default String getSessionId() {
+		// this added as a default method to 5.x to preserve api compatibility
+		throw new UnsupportedOperationException();
+	}
+	
 	/**
 	 * @return the handler instance that was used to authenticate.
 	 */

--- a/src/test/java/org/subethamail/smtp/server/BasicMessageHandlerFactoryTest.java
+++ b/src/test/java/org/subethamail/smtp/server/BasicMessageHandlerFactoryTest.java
@@ -43,7 +43,7 @@ public class BasicMessageHandlerFactoryTest {
                 .port(PORT) //
                 .messageHandler(
                         (context, from, to,
-                                data) -> System.out.println("message from " + from + " to " + to
+                                data) -> System.out.println("message from " + from + " to " + to  + ", sessionId=" + context.getSessionId()
                                         + ":\n" + new String(data, StandardCharsets.UTF_8)))
                 .build();
         try {


### PR DESCRIPTION
See discussion in #30, MessageContext.getSessionId is useful to be able to associate sessions passed through a SessionHandler with a message passed through a MessageHandler.