### PR TITLE
Fix buggy email extraction with AUTH verb

### DIFF
--- a/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
+++ b/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
@@ -32,6 +32,19 @@ public class EmailUtilsTest {
     }
 
     @Test
+    public void testExtractNullSender() {
+        assertEquals("",
+            extractAndValidate("FROM:<>", 5));
+    }
+
+    @Test
+    public void testExtractNullSenderWithPrecedingSpace() {
+        assertEquals("",
+            extractAndValidate("FROM: <>", 5));
+    }
+
+
+    @Test
     public void testExtractWithNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
         assertEquals("test@example.com",
             extractAndValidate("FROM: test@example.com", 5));
@@ -57,39 +70,107 @@ public class EmailUtilsTest {
     }
 
     @Test
-    public void testExtractWithAuthVerb() {
+    public void testExtractWithAuthVerbNullSender() {
         assertEquals("test@example.com",
             extractAndValidate("FROM:<test@example.com> AUTH=<>", 5));
     }
 
     @Test
-    public void testExtractWithAuthVerbAndSpaces() {
+    public void testExtractWithAuth() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:<test@example.com> AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractNullSenderWithAuthNullSender() {
+        assertEquals("",
+            extractAndValidate("FROM:<> AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractNullSenderWithAuth() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("",
+            extractAndValidate("FROM:<> AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractNullSenderWithAuthNullSenderAndPrecedingSpace() {
+        assertEquals("",
+            extractAndValidate("FROM: <> AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractNullSenderWithAuthAndPrecedingSpace() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("",
+            extractAndValidate("FROM: <> AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbNullSenderAndSpaces() {
         assertEquals("test@example.com",
             extractAndValidate("FROM:< test@example.com > AUTH=<>", 5));
     }
 
     @Test
-    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmail() {
+    public void testExtractWithAuthVerbAndSpaces() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:< test@example.com > AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbNullSenderAndNoLessThanSymbolAtStartOfEmail() {
         assertEquals("test@example.com",
             extractAndValidate("FROM:test@example.com AUTH=<>", 5));
     }
 
     @Test
-    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
+    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmail() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:test@example.com AUTH=<some@example.com>>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbNullSenderAndNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
         assertEquals("test@example.com",
             extractAndValidate("FROM: test@example.com AUTH=<>", 5));
     }
 
     @Test
-    public void testExtractWithAuthVerbAndEmbeddedPersonalName() {
+    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("test@example.com",
+            extractAndValidate("FROM: test@example.com AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbNullSenderAndEmbeddedPersonalName() {
         assertEquals("Foo Bar <foobar@example.com>",
             extractAndValidate("FROM:<Foo Bar <foobar@example.com>> AUTH=<>", 5));
     }
 
     @Test
-    public void testExtractWithAuthVerbAndEmbeddedPersonalNameAndSpaces() {
+    public void testExtractWithAuthVerbAndEmbeddedPersonalName() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("Foo Bar <foobar@example.com>",
+            extractAndValidate("FROM:<Foo Bar <foobar@example.com>> AUTH=<some@example.com>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbNullSenderAndEmbeddedPersonalNameAndSpaces() {
         assertEquals("Foo Bar < foobar@example.com >",
             extractAndValidate("FROM:<Foo Bar < foobar@example.com >> AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndEmbeddedPersonalNameAndSpaces() {
+        // AUTH=<some@example.com> out of specs but better safe than sorry
+        assertEquals("Foo Bar < foobar@example.com >",
+            extractAndValidate("FROM:<Foo Bar < foobar@example.com >> AUTH=<some@example.com>", 5));
     }
 
     private static String extractAndValidate(String args, int offset) {

--- a/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
+++ b/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
@@ -56,9 +56,45 @@ public class EmailUtilsTest {
             extractAndValidate("FROM:<Foo Bar <foobar@example.com>>", 5));
     }
 
+    @Test
+    public void testExtractWithAuthVerb() {
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:<test@example.com> AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndSpaces() {
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:< test@example.com > AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmail() {
+        assertEquals("test@example.com",
+            extractAndValidate("FROM:test@example.com AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndNoLessThanSymbolAtStartOfEmailAndPrecedingSpace() {
+        assertEquals("test@example.com",
+            extractAndValidate("FROM: test@example.com AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndEmbeddedPersonalName() {
+        assertEquals("Foo Bar <foobar@example.com>",
+            extractAndValidate("FROM:<Foo Bar <foobar@example.com>> AUTH=<>", 5));
+    }
+
+    @Test
+    public void testExtractWithAuthVerbAndEmbeddedPersonalNameAndSpaces() {
+        assertEquals("Foo Bar < foobar@example.com >",
+            extractAndValidate("FROM:<Foo Bar < foobar@example.com >> AUTH=<>", 5));
+    }
+
     private static String extractAndValidate(String args, int offset) {
         String address = EmailUtils.extractEmailAddress(args, offset);
-        assertTrue(EmailUtils.isValidEmailAddress(address));
+        assertTrue(address + " isn't a valid address", EmailUtils.isValidEmailAddress(address));
         return address;
     }
 }


### PR DESCRIPTION
This issue is needed to cover a bug introduced with #18.

The issue arise when a https://tools.ietf.org/html/rfc4954 compliant client connect to subethamail. Mail commands will be received in this form:
MAIL FROM:<john+@example.org> AUTH=<>

See https://tools.ietf.org/html/rfc4954#section-5

This patch change extraction behavior checking for brackets open/close and not expanding email address to the last '>'

Added some testcases