### PR TITLE
Update to Jakarta Mail 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <version>1.6.5</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/subethamail/smtp/internal/util/EmailUtils.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/EmailUtils.java
@@ -1,8 +1,9 @@
 package org.subethamail.smtp.internal.util;
 
 import com.github.davidmoten.guavamini.Preconditions;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 
 /**
  * @author Jeff Schnitzer

--- a/src/main/java/org/subethamail/wiser/Wiser.java
+++ b/src/main/java/org/subethamail/wiser/Wiser.java
@@ -15,15 +15,15 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.mail.MessagingException;
-import javax.mail.Session;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.subethamail.smtp.TooMuchDataException;
 import org.subethamail.smtp.helper.SimpleMessageListener;
 import org.subethamail.smtp.server.SMTPServer;
 import org.subethamail.smtp.server.SMTPServer.Builder;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
 
 /**
  * Wiser is a tool for unit testing applications that send mail. Your unit tests

--- a/src/main/java/org/subethamail/wiser/WiserMessage.java
+++ b/src/main/java/org/subethamail/wiser/WiserMessage.java
@@ -3,11 +3,11 @@ package org.subethamail.wiser;
 import java.io.ByteArrayInputStream;
 import java.io.PrintStream;
 
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.MimeMessage;
-
 import org.subethamail.smtp.internal.Constants;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
 
 /**
  * This class wraps a received message and provides a way to generate a JavaMail

--- a/src/test/java/org/subethamail/smtp/BigAttachmentTest.java
+++ b/src/test/java/org/subethamail/smtp/BigAttachmentTest.java
@@ -13,19 +13,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
 
-import javax.activation.DataHandler;
-import javax.activation.FileDataSource;
-import javax.mail.Address;
-import javax.mail.Message;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.URLName;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -35,6 +22,19 @@ import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
 
 import com.sun.mail.smtp.SMTPTransport;
+
+import jakarta.activation.DataHandler;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.URLName;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 /**
  * This class tests the transfer speed of emails that carry

--- a/src/test/java/org/subethamail/smtp/ErrorResponseTest.java
+++ b/src/test/java/org/subethamail/smtp/ErrorResponseTest.java
@@ -9,26 +9,26 @@ import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.BodyPart;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-
 import org.junit.Test;
 import org.subethamail.smtp.helper.BasicMessageListener;
 import org.subethamail.smtp.server.SMTPServer;
 
 import com.sun.mail.smtp.SMTPSendFailedException;
+
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 public class ErrorResponseTest {
 

--- a/src/test/java/org/subethamail/smtp/MessageContentTest.java
+++ b/src/test/java/org/subethamail/smtp/MessageContentTest.java
@@ -6,17 +6,17 @@ import java.util.Arrays;
 import java.util.Properties;
 import java.util.Random;
 
-import javax.activation.DataHandler;
-import javax.mail.Message;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import javax.mail.util.ByteArrayDataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.subethamail.wiser.Wiser;
+
+import jakarta.activation.DataHandler;
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.util.ByteArrayDataSource;
 
 import junit.framework.Test;
 import junit.framework.TestCase;

--- a/src/test/java/org/subethamail/smtp/StartStopTest.java
+++ b/src/test/java/org/subethamail/smtp/StartStopTest.java
@@ -2,15 +2,15 @@ package org.subethamail.smtp;
 
 import java.util.Properties;
 
-import javax.mail.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.subethamail.wiser.Wiser;
+
+import jakarta.mail.Session;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.subethamail.wiser.Wiser;
 
 /**
  * This class attempts to quickly start/stop 10 Wiser servers. It makes sure that the socket bind address is correctly

--- a/src/test/java/org/subethamail/smtp/TestUtil.java
+++ b/src/test/java/org/subethamail/smtp/TestUtil.java
@@ -11,19 +11,6 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Properties;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.BodyPart;
-import javax.mail.Message;
-import javax.mail.Multipart;
-import javax.mail.PasswordAuthentication;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -32,6 +19,20 @@ import javax.net.ssl.TrustManager;
 import org.subethamail.util.ExtendedTrustManager;
 
 import com.sun.mail.util.MailSSLSocketFactory;
+
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.Multipart;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 class TestUtil {
 
@@ -105,7 +106,7 @@ class TestUtil {
         if (username == null) {
             session = Session.getInstance(props);
         } else {
-            session = Session.getInstance(props, new javax.mail.Authenticator() {
+            session = Session.getInstance(props, new jakarta.mail.Authenticator() {
                 protected PasswordAuthentication getPasswordAuthentication() {
                     return new PasswordAuthentication(username, password);
                 }

--- a/src/test/java/org/subethamail/smtp/WiserFailuresTest.java
+++ b/src/test/java/org/subethamail/smtp/WiserFailuresTest.java
@@ -9,19 +9,19 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.Properties;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-
-import junit.framework.TestCase;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import junit.framework.TestCase;
 
 /**
  * This class tests various aspects of the server for smtp compliance by using
@@ -216,7 +216,7 @@ public class WiserFailuresTest extends TestCase {
                 transport.sendMessage(msg,
                         InternetAddress.parse("dimiter.bakardjiev@musala.com", false));
                 assertEquals(2, this.server.getMessages().size());
-            } catch (javax.mail.MessagingException me) {
+            } catch (jakarta.mail.MessagingException me) {
                 me.printStackTrace();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/test/java/org/subethamail/smtp/server/BasicMessageHandlerFactoryTest.java
+++ b/src/test/java/org/subethamail/smtp/server/BasicMessageHandlerFactoryTest.java
@@ -12,19 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.BodyPart;
-import javax.mail.Message;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-
 import org.junit.Test;
 import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.MessageHandler;
@@ -32,6 +19,19 @@ import org.subethamail.smtp.RejectException;
 import org.subethamail.smtp.TooMuchDataException;
 import org.subethamail.smtp.helper.BasicMessageHandlerFactory;
 import org.subethamail.smtp.helper.BasicMessageListener;
+
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.activation.FileDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Message;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 
 public class BasicMessageHandlerFactoryTest {
 

--- a/src/test/java/org/subethamail/smtp/server/MessageHandlerTest.java
+++ b/src/test/java/org/subethamail/smtp/server/MessageHandlerTest.java
@@ -3,8 +3,6 @@ package org.subethamail.smtp.server;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.mail.MessagingException;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -17,6 +15,8 @@ import org.subethamail.smtp.RejectException;
 import org.subethamail.smtp.client.SMTPException;
 import org.subethamail.smtp.client.SmartClient;
 import org.subethamail.smtp.internal.util.TextUtils;
+
+import jakarta.mail.MessagingException;
 
 /**
  * This class tests whether the event handler methods defined in MessageHandler


### PR DESCRIPTION
They have upgraded Jakarta Mail to 2.0 which mainly is a rename of `javax.mail` to `jakarta.mail` and a minimum version of Java 8.