### PR TITLE
Handle SSLSockets correctly in Session constructor

### DIFF
--- a/src/main/java/org/subethamail/smtp/server/Session.java
+++ b/src/main/java/org/subethamail/smtp/server/Session.java
@@ -1,17 +1,5 @@
 package org.subethamail.smtp.server;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.security.cert.Certificate;
-import java.util.Map;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -24,6 +12,16 @@ import org.subethamail.smtp.internal.proxy.ProxyHandler;
 import org.subethamail.smtp.internal.proxy.ProxyHandler.ProxyResult;
 import org.subethamail.smtp.internal.server.ServerThread;
 import org.subethamail.smtp.server.SessionHandler.SessionAcceptance;
+
+import javax.net.ssl.SSLSocket;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.*;
+import java.security.cert.Certificate;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * The thread that handles a connection. This class passes most of it's
@@ -116,6 +114,7 @@ public final class Session implements Runnable, MessageContext {
         this.serverThread = serverThread;
         this.remoteAddress = (InetSocketAddress) socket.getRemoteSocketAddress();
         this.setSocket(socket);
+        this.tlsStarted = socket instanceof SSLSocket;
         this.proxyHandler = proxyHandler;
     }
 

--- a/src/main/java/org/subethamail/smtp/server/Session.java
+++ b/src/main/java/org/subethamail/smtp/server/Session.java
@@ -1,5 +1,18 @@
 package org.subethamail.smtp.server;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.security.cert.Certificate;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -12,16 +25,6 @@ import org.subethamail.smtp.internal.proxy.ProxyHandler;
 import org.subethamail.smtp.internal.proxy.ProxyHandler.ProxyResult;
 import org.subethamail.smtp.internal.server.ServerThread;
 import org.subethamail.smtp.server.SessionHandler.SessionAcceptance;
-
-import javax.net.ssl.SSLSocket;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.net.*;
-import java.security.cert.Certificate;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * The thread that handles a connection. This class passes most of it's


### PR DESCRIPTION
The previous implementation assumed, that the socket to start with is never an `SSLSocket`, which is not true as it is possible to change this by changing the `serverSocketFactory`.

This change is necessary as otherwise it is not possible that subethasmtp provides full TLS support (as the readme suggests).

Please note: This is a bugfix, not only an improvement (previously, when trying to use TLS, subethasmtp ONLY worked when using STARTTLS).