### PR TITLE
The RCPT TO can be called more than once

### DIFF
--- a/src/main/java/org/subethamail/smtp/helper/BasicMessageHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/helper/BasicMessageHandlerFactory.java
@@ -1,14 +1,12 @@
 package org.subethamail.smtp.helper;
 
+import org.subethamail.smtp.*;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import org.subethamail.smtp.MessageContext;
-import org.subethamail.smtp.MessageHandler;
-import org.subethamail.smtp.MessageHandlerFactory;
-import org.subethamail.smtp.RejectException;
-import org.subethamail.smtp.TooMuchDataException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BasicMessageHandlerFactory implements MessageHandlerFactory {
 
@@ -30,7 +28,7 @@ public class BasicMessageHandlerFactory implements MessageHandlerFactory {
         private final BasicMessageListener listener;
 
         private String from;
-        private String recipient;
+        private List<String> recipients = new ArrayList<>();
 
         private final MessageContext context;
         private final int maxMessageSize;
@@ -50,7 +48,7 @@ public class BasicMessageHandlerFactory implements MessageHandlerFactory {
 
         @Override
         public void recipient(String recipient) throws RejectException {
-            this.recipient = recipient;
+            this.recipients.add(recipient);
         }
 
         @Override
@@ -63,10 +61,10 @@ public class BasicMessageHandlerFactory implements MessageHandlerFactory {
                 if (from == null) {
                     throw new RejectException("from not set");
                 }
-                if (recipient == null) {
-                    throw new RejectException("recipient not set");
+                if (recipients.isEmpty()) {
+                    throw new RejectException("recipients not set");
                 }
-                listener.messageArrived(context, from, recipient, bytes);
+                listener.messageArrived(context, from, recipients, bytes);
 
                 return null;
             } catch (RuntimeException e) {

--- a/src/main/java/org/subethamail/smtp/helper/BasicMessageListener.java
+++ b/src/main/java/org/subethamail/smtp/helper/BasicMessageListener.java
@@ -3,6 +3,8 @@ package org.subethamail.smtp.helper;
 import org.subethamail.smtp.MessageContext;
 import org.subethamail.smtp.RejectException;
 
+import java.util.List;
+
 public interface BasicMessageListener {
 
     /**
@@ -18,6 +20,6 @@ public interface BasicMessageListener {
      * @throws RejectException
      *             when caller to be given an SMTP error response
      */
-    void messageArrived(MessageContext context, String from, String to, byte[] data) throws RejectException;
+    void messageArrived(MessageContext context, String from, List<String> to, byte[] data) throws RejectException;
 
 }

--- a/src/test/java/org/subethamail/smtp/BdatTest.java
+++ b/src/test/java/org/subethamail/smtp/BdatTest.java
@@ -1,18 +1,19 @@
 package org.subethamail.smtp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.subethamail.smtp.client.SMTPException;
 import org.subethamail.smtp.client.SmartClient;
 import org.subethamail.smtp.helper.BasicMessageListener;
 import org.subethamail.smtp.server.SMTPServer;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BdatTest {
 
@@ -137,13 +138,13 @@ public class BdatTest {
     static final class MyListener implements BasicMessageListener {
 
         String from;
-        String to;
+        List<String> to;
         byte[] data;
 
         int count = 0;
 
         @Override
-        public void messageArrived(MessageContext context, String from, String to, byte[] data) throws RejectException {
+        public void messageArrived(MessageContext context, String from, List<String> to, byte[] data) throws RejectException {
             this.from = from;
             this.to = to;
             this.data = data;

--- a/src/test/java/org/subethamail/smtp/ErrorResponseTest.java
+++ b/src/test/java/org/subethamail/smtp/ErrorResponseTest.java
@@ -1,34 +1,22 @@
 package org.subethamail.smtp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.util.Properties;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import com.sun.mail.smtp.SMTPSendFailedException;
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
 import jakarta.activation.FileDataSource;
-import jakarta.mail.BodyPart;
-import jakarta.mail.Message;
-import jakarta.mail.MessagingException;
-import jakarta.mail.Multipart;
-import jakarta.mail.Session;
-import jakarta.mail.Transport;
-import jakarta.mail.internet.AddressException;
-import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeBodyPart;
-import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
-
+import jakarta.mail.*;
+import jakarta.mail.internet.*;
 import org.junit.Test;
 import org.subethamail.smtp.helper.BasicMessageListener;
 import org.subethamail.smtp.server.SMTPServer;
 
-import com.sun.mail.smtp.SMTPSendFailedException;
+import java.io.File;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
 
 public class ErrorResponseTest {
 
@@ -45,7 +33,7 @@ public class ErrorResponseTest {
             int count = 0;
 
             @Override
-            public void messageArrived(MessageContext context, String from, String to, byte[] data)
+            public void messageArrived(MessageContext context, String from, List<String> to, byte[] data)
                     throws RejectException {
                 count++;
                 if (count == 1) {


### PR DESCRIPTION
This pull request addresses issue #36 

The RCPT TO command can be called more than once, but the `BasicMessageHandler` did not take this into account.

documentation for the `recipient(String recipient)` function of `MessageHandler`:
>  Called once for every RCPT TO during a SMTP exchange. This will occur after a from() call.

This is a breaking change.