### PR TITLE
findbugs-annotations scope changed compile -> test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs-annotations</artifactId>
             <version>3.0.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.davidmoten</groupId>


### PR DESCRIPTION
Dependency findbugs-annotations has scope compile, but used only in tests. It seems, correct scope for it is test, not compile