### PR TITLE
Don't fail so hard on base64 decoding failures

### DIFF
--- a/src/main/java/org/subethamail/smtp/auth/LoginAuthenticationHandlerFactory.java
+++ b/src/main/java/org/subethamail/smtp/auth/LoginAuthenticationHandlerFactory.java
@@ -82,10 +82,15 @@ public final class LoginAuthenticationHandlerFactory implements AuthenticationHa
 					// the username.
 					// .Net's built in System.Net.Mail.SmtpClient sends its
 					// authentication this way (and this way only).
-					byte[] decoded = Base64.getDecoder().decode(stk.nextToken());
-					if (decoded == null)
-						throw new RejectException(501, /*5.5.4*/
-								"Invalid command argument, not a valid Base64 string"); 
+					byte[] decoded;
+					try
+					{
+						decoded = Base64.getDecoder().decode(stk.nextToken());
+					} catch (IllegalArgumentException x)
+					{
+						throw new RejectException(501, /* 5.5.4 */
+								"Invalid command argument, not a valid Base64 string");
+					}
 					username = TextUtils.getStringUtf8(decoded);
 
 					return Optional.of("334 "
@@ -98,28 +103,23 @@ public final class LoginAuthenticationHandlerFactory implements AuthenticationHa
 				}
 			}
 
-			if (this.username == null)
+			byte[] decoded;
+			try 
 			{
-				byte[] decoded = Base64.getDecoder().decode(clientInput);
-				if (decoded == null)
-				{
-					throw new RejectException(501, /*5.5.4*/
-							"Invalid command argument, not a valid Base64 string");
-				}
+				decoded = Base64.getDecoder().decode(clientInput);
+			} catch (IllegalArgumentException x)
+			{
+				throw new RejectException(501, /* 5.5.4 */
+					"Invalid command argument, not a valid Base64 string");
+			}
 
+			if (this.username == null) {
 				this.username = TextUtils.getStringUtf8(decoded);
-
 				return Optional.of("334 "
 						+ Base64.getEncoder().encodeToString(
 								TextUtils.getAsciiBytes("Password:")));
 			}
 
-			byte[] decoded = Base64.getDecoder().decode(clientInput);
-			if (decoded == null)
-			{
-				throw new RejectException(501, /*5.5.4*/
-						"Invalid command argument, not a valid Base64 string");
-			}
 
 			String password = TextUtils.getStringUtf8(decoded);
 			try

--- a/src/test/java/org/subethamail/smtp/command/AuthTest.java
+++ b/src/test/java/org/subethamail/smtp/command/AuthTest.java
@@ -172,7 +172,6 @@ public class AuthTest extends ServerTestCase {
         expect("535");
     }
 
-
     /**
      * Test behaviour of an empty password in login auth.
      */
@@ -192,5 +191,56 @@ public class AuthTest extends ServerTestCase {
 
         send("");
         expect("535");
+    }
+
+    /**
+     * AUTH LOGIN usernames that are not validly base-64 encoded return 501
+     */
+    public void testBadUser() throws Exception {
+        expect("220");
+
+        send("HELO foo.com");
+        expect("250");
+
+        send("AUTH LOGIN");
+        expect("334");
+
+        send("bad-username");
+        expect("501");
+    }
+
+    /**
+     * AUTH LOGIN usernames that are not validly base-64 encoded return 501 when passed inline
+     */
+    public void testBadUserInline() throws Exception {
+        expect("220");
+
+        send("HELO foo.com");
+        expect("250");
+
+        send("AUTH LOGIN bad-username");
+        expect("501");
+    }
+
+    /**
+     * Tests that AUTH LOGIN usernames that are not validly base-64 encoded return
+     * 501
+     */
+    public void testBadPass() throws Exception {
+        expect("220");
+
+        send("HELO foo.com");
+        expect("250");
+
+        send("AUTH LOGIN");
+        expect("334");
+
+        String enc_username = Base64.getEncoder().encodeToString(TextUtils.getAsciiBytes(REQUIRED_USERNAME));
+
+        send(enc_username);
+        expect("334");
+
+        send("bad-password");
+        expect("501");
     }
 }


### PR DESCRIPTION
Decoder.decode throws an IllegalArgumentException upon decoding invalid base64.

Catch the exception, and return failure when that happens.

Slight boyscout-ruling: DRY up the repeated handling of user and pass