### PR TITLE
support SMTPUTF8 #132

### DIFF
--- a/src/main/java/org/subethamail/smtp/internal/command/EhloCommand.java
+++ b/src/main/java/org/subethamail/smtp/internal/command/EhloCommand.java
@@ -70,6 +70,9 @@ public final class EhloCommand extends BaseCommand
 		// Chunking (BDAT) support
 		response.append("\r\n250-CHUNKING");
 
+		// SMTPUTF8 support
+		response.append("\r\n250-SMTPUTF8");
+		
 		// Check to see if we support authentication
 		Optional<AuthenticationHandlerFactory> authFact = sess.getServer().getAuthenticationHandlerFactory();
         final boolean displayAuth;

--- a/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
@@ -75,7 +75,7 @@ public final class CRLFTerminatedReader extends Reader
 		}
 	}
 
-	private final InputStreamReader in;
+	private final Reader in;
 
 	/**
 	 * Constructs this CRLFTerminatedReader.
@@ -88,7 +88,7 @@ public final class CRLFTerminatedReader extends Reader
 
 	public CRLFTerminatedReader(InputStream in)
 	{
-		this.in = new InputStreamReader(in, StandardCharsets.UTF_8);
+		this.in = new Utf8InputStreamReader(in);
 	}
 
 	private final StringBuffer lineBuffer = new StringBuffer();

--- a/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
@@ -19,10 +19,8 @@ package org.subethamail.smtp.internal.io;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 /**
  * A Reader for use with SMTP or other protocols in which lines
  * must end with CRLF.  Extends Reader and overrides its

--- a/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/CRLFTerminatedReader.java
@@ -19,8 +19,10 @@ package org.subethamail.smtp.internal.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 /**
  * A Reader for use with SMTP or other protocols in which lines
  * must end with CRLF.  Extends Reader and overrides its
@@ -73,7 +75,7 @@ public final class CRLFTerminatedReader extends Reader
 		}
 	}
 
-	private final InputStream in;
+	private final InputStreamReader in;
 
 	/**
 	 * Constructs this CRLFTerminatedReader.
@@ -86,7 +88,7 @@ public final class CRLFTerminatedReader extends Reader
 
 	public CRLFTerminatedReader(InputStream in)
 	{
-		this.in = in;
+		this.in = new InputStreamReader(in, StandardCharsets.UTF_8);
 	}
 
 	private final StringBuffer lineBuffer = new StringBuffer();
@@ -189,13 +191,13 @@ public final class CRLFTerminatedReader extends Reader
 	@Override
 	public boolean ready() throws IOException
 	{
-		return this.in.available() > 0;
+		return this.in.ready();
 	}
 
 	@Override
 	public int read(char[] cbuf, int off, int len) throws IOException
 	{
-		byte[] temp = new byte[len];
+		char[] temp = new char[len];
 		int result = this.in.read(temp, 0, len);
 		for (int i = 0; i < result; i++)
 			cbuf[i] = (char) temp[i];

--- a/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
@@ -67,7 +67,7 @@ public final class Utf8InputStreamReader extends Reader {
                     throw new EOFException();
                 }
                 if (!isContinuation(a)) {
-                    throw new IllegalStateException(
+                    throw new IOException(
                             "wrong continuation bits, bytes after first in a UTF-8 character must start with bits 10");
                 }
                 bb.put(a);
@@ -96,12 +96,12 @@ public final class Utf8InputStreamReader extends Reader {
     }
 
     // VisibleForTesting
-    static int numBytes(int a) {
+    static int numBytes(int a) throws IOException {
         if (!bit(a, 1)) {
             return 1;
         } else {
             if (!bit(a, 2)) {
-                throw new IllegalStateException("leading bits 10 illegal for first byte of UTF-8 character");
+                throw new IOException("leading bits 10 illegal for first byte of UTF-8 character");
             } else if (!bit(a, 3)) {
                 return 2;
             } else {
@@ -111,7 +111,7 @@ public final class Utf8InputStreamReader extends Reader {
                     if (!bit(a, 5)) {
                         return 4;
                     } else {
-                        throw new IllegalStateException("leading bits 11111 illegal for first byte of UTF-8 character");
+                        throw new IOException("leading bits 11111 illegal for first byte of UTF-8 character");
                     }
                 }
             }

--- a/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
@@ -88,34 +88,27 @@ public final class Utf8InputStreamReader extends Reader {
     }
 
     private static boolean isContinuation(int a) {
-        boolean b1 = ((a >> 7) & 1) == 1;
-        if (!b1) {
+        if (!bit(a, 1)) {
             return false;
         } else {
-            boolean b2 = ((a >> 6) & 1) == 1;
-            return !b2;
+            return !bit(a, 2);
         }
     }
 
     // VisibleForTesting
     static int numBytes(int a) {
-        boolean b1 = bit(a, 1);
-        if (!b1) {
+        if (!bit(a, 1)) {
             return 1;
         } else {
-            boolean b2 = bit(a, 2);
-            boolean b3 = bit(a, 3);
-            if (!b2) {
+            if (!bit(a, 2)) {
                 throw new IllegalStateException("leading bits 10 illegal for first byte of UTF-8 character");
-            } else if (!b3) {
+            } else if (!bit(a, 3)) {
                 return 2;
             } else {
-                boolean b4 = bit(a, 4);
-                if (!b4) {
+                if (!bit(a, 4)) {
                     return 3;
                 } else {
-                    boolean b5 = bit(a, 5);
-                    if (!b5) {
+                    if (!bit(a, 5)) {
                         return 4;
                     } else {
                         throw new IllegalStateException("leading bits 11111 illegal for first byte of UTF-8 character");

--- a/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
@@ -1,4 +1,4 @@
-package org.subethamail.smtp.internal.util;
+package org.subethamail.smtp.internal.io;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/src/main/java/org/subethamail/smtp/internal/util/Utf8InputStreamReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/util/Utf8InputStreamReader.java
@@ -1,0 +1,110 @@
+package org.subethamail.smtp.internal.util;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * No-buffering InputStream Reader for UTF-8 encoded strings.
+ */
+public final class Utf8InputStreamReader extends Reader {
+
+    private static final CharsetDecoder DECODER = StandardCharsets.UTF_8.newDecoder();
+
+    private final InputStream in;
+    private final ByteBuffer bb = ByteBuffer.allocate(4);
+
+    public Utf8InputStreamReader(InputStream in) {
+        this.in = in;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        for (int i = off; i < off + len; i++) {
+            int a = read();
+            if (a == -1) {
+                if (i == off) {
+                    return -1;
+                } else {
+                    return i - off;
+                }
+            }
+            cbuf[i] = (char) a;
+        }
+        return len;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = in.read();
+        if (b == -1) {
+            return b;
+        }
+        int numBytes = numBytes(b);
+        if (numBytes == 1) {
+            return b;
+        } else {
+            bb.clear();
+            bb.put((byte) b);
+            for (int i = 0; i < numBytes - 1; i++) {
+                byte a = (byte) in.read();
+                if (a == -1) {
+                    throw new EOFException();
+                }
+                if (!isContinuation(a)) {
+                    throw new IllegalStateException("wrong continuation bits");
+                }
+                bb.put(a);
+            }
+            bb.flip();
+            return DECODER.decode(bb).get();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    private static boolean isContinuation(int a) {
+        boolean b1 = ((a >> 7) & 1) == 1;
+        if (!b1) {
+            return false;
+        } else {
+            boolean b2 = ((a >> 6) & 1) == 1;
+            return !b2;
+        }
+    }
+
+    private static int numBytes(int a) {
+        boolean b1 = ((a >> 7) & 1) == 1;
+        if (!b1) {
+            return 1;
+        } else {
+            boolean b2 = ((a >> 6) & 1) == 1;
+            boolean b3 = ((a >> 5) & 1) == 1;
+            if (!b2) {
+                throw new IllegalStateException();
+            } else if (!b3) {
+                return 2;
+            } else {
+                boolean b4 = ((a >> 4) & 1) == 1;
+                if (!b4) {
+                    return 3;
+                } else {
+                    boolean b5 = ((a >> 3) & 1) == 1;
+                    if (!b5) {
+                        return 4;
+                    } else {
+                        throw new IllegalStateException();
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
+++ b/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
@@ -28,10 +28,11 @@ public class SmartClientTest {
             assertEquals("clientHeloHost", client.getHeloHost());
             assertEquals(0, client.getRecipientCount());
             Assert.assertFalse(client.getAuthenticator().isPresent());
-            assertEquals(3, client.getExtensions().size());
+            assertEquals(4, client.getExtensions().size());
             Set<String> set = client.getExtensions().keySet();
             assertTrue(set.contains("8BITMIME"));
             assertTrue(set.contains("CHUNKING"));
+            assertTrue(set.contains("SMTPUTF8"));
             //TODO why is OK in client.getExtensions?
         } finally {
             server.stop();

--- a/src/test/java/org/subethamail/smtp/command/EhloCommandTest.java
+++ b/src/test/java/org/subethamail/smtp/command/EhloCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +30,7 @@ public class EhloCommandTest {
         System.out.println(output);
         assertTrue(output.contains("250-STARTTLS"));
         assertFalse(output.contains("250-AUTH PLAIN"));
+        assertTrue(output.contains("250-SMTPUTF8"));
     }
     
     @Test
@@ -62,6 +64,8 @@ public class EhloCommandTest {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             Socket socket = Mockito.mock(Socket.class);
             Mockito.when(socket.getOutputStream()).thenReturn(out);
+            InputStream in = Mockito.mock(InputStream.class);
+            Mockito.when(socket.getInputStream()).thenReturn(in);
             SMTPServer server = SMTPServer //
                     .port(ss.getLocalPort()) //
                     .serverSocketFactory(() -> ss) //
@@ -84,8 +88,7 @@ public class EhloCommandTest {
             Session session = new Session(server, new ServerThread(server, ss, ProxyHandler.NOP), socket, ProxyHandler.NOP);
             session.setTlsStarted(isTlsStarted);
             ec.execute("EHLO me.com", session);
-            String output = new String(out.toByteArray(), StandardCharsets.UTF_8);
-            return output;
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
         }
     }
 

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -13,7 +14,13 @@ public class Utf8InputStreamReaderTest {
 
     @Test
     public void test() throws IOException {
-        String s = "$£Иह€한薠";
+        final char[] chars = Character.toChars(0x1F701);
+        final String str = new String(chars);
+        final byte[] asBytes = str.getBytes(StandardCharsets.UTF_8);
+        System.out.println(chars.length);
+        System.out.println(str);
+        System.out.println(Arrays.toString(asBytes));
+        String s = "$£Иह€한薠" + (char) 0x1F701;
         try (Reader r = reader(s)) {
             assertEquals('$', (char) r.read());
             assertEquals('£', (char) r.read());
@@ -22,8 +29,8 @@ public class Utf8InputStreamReaderTest {
             assertEquals('€', (char) r.read());
             assertEquals('한', (char) r.read());
             assertEquals('薠', (char) r.read());
+            assertEquals(s.charAt(s.length() - 1), (char) r.read());
             assertEquals(-1, r.read());
-            System.out.println((char) 0x10348);
         }
     }
 

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -1,12 +1,12 @@
 package org.subethamail.smtp.internal.io;
 
 import static org.junit.Assert.assertEquals;
+import static org.subethamail.smtp.internal.io.Utf8InputStreamReader.numBytes;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -15,12 +15,9 @@ public class Utf8InputStreamReaderTest {
     @Test
     public void test() throws IOException {
         final char[] chars = Character.toChars(0x1F701);
+        assertEquals(2, chars.length); 
         final String str = new String(chars);
-        final byte[] asBytes = str.getBytes(StandardCharsets.UTF_8);
-        System.out.println(chars.length);
-        System.out.println(str);
-        System.out.println(Arrays.toString(asBytes));
-        String s = "$£Иह€한薠" + (char) 0x1F701;
+        String s = "$£Иह€한薠" + str;
         try (Reader r = reader(s)) {
             assertEquals('$', (char) r.read());
             assertEquals('£', (char) r.read());
@@ -29,9 +26,17 @@ public class Utf8InputStreamReaderTest {
             assertEquals('€', (char) r.read());
             assertEquals('한', (char) r.read());
             assertEquals('薠', (char) r.read());
-            assertEquals(s.charAt(s.length() - 1), (char) r.read());
+            char[] chrs = new char[2];
+            assertEquals(2, r.read(chrs));
+            assertEquals(55357, chrs[0]);
+            assertEquals(57089, chrs[1]);
             assertEquals(-1, r.read());
         }
+    }
+    
+    @Test
+    public void testNumBytes() {
+        assertEquals(1, numBytes('$'));
     }
 
     private static Utf8InputStreamReader reader(String s) {

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -64,7 +64,7 @@ public class Utf8InputStreamReaderTest {
         byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
         byte[] b = new byte[] { bytes[0], bytes[0] };
         try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
-            assertThrows(IllegalStateException.class, () -> r.read());
+            assertThrows(IOException.class, () -> r.read());
         }
     }
 
@@ -73,7 +73,7 @@ public class Utf8InputStreamReaderTest {
         byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
         byte[] b = new byte[] { bytes[0], '$' };
         try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
-            assertThrows(IllegalStateException.class, () -> r.read());
+            assertThrows(IOException.class, () -> r.read());
         }
     }
 
@@ -82,7 +82,7 @@ public class Utf8InputStreamReaderTest {
         byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
         byte[] b = new byte[] { bytes[1] };
         try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
-            assertThrows(IllegalStateException.class, () -> r.read());
+            assertThrows(IOException.class, () -> r.read());
         }
     }
 
@@ -90,12 +90,12 @@ public class Utf8InputStreamReaderTest {
     public void testUtf8ByteHasTooManyLeadingOnes() throws IOException {
         byte[] b = new byte[] { (byte) 248 };
         try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
-            assertThrows(IllegalStateException.class, () -> r.read());
+            assertThrows(IOException.class, () -> r.read());
         }
     }
 
     @Test
-    public void testNumBytes() {
+    public void testNumBytes() throws IOException {
         assertEquals(1, numBytes('$'));
     }
 

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -35,6 +35,20 @@ public class Utf8InputStreamReaderTest {
     }
     
     @Test
+    public void testReadIntoArray() throws IOException {
+        final char[] chars = Character.toChars(0x1F701);
+        final String str = new String(chars);
+        String s = "$£Иह€한薠" + str;
+        try (Reader r = reader(s)) {
+            char[] chrs = new char[1000];
+            int n = r.read(chrs, 0, 2);
+            n+= r.read(chrs, 2, 1000);
+            assertEquals(9, n);
+            assertEquals(-1, r.read(chrs));
+        }
+    }
+    
+    @Test
     public void testNumBytes() {
         assertEquals(1, numBytes('$'));
     }

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -1,0 +1,34 @@
+package org.subethamail.smtp.internal.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class Utf8InputStreamReaderTest {
+
+    @Test
+    public void test() throws IOException {
+        String s = "$£Иह€한薠";
+        try (Reader r = reader(s)) {
+            assertEquals('$', (char) r.read());
+            assertEquals('£', (char) r.read());
+            assertEquals('И', (char) r.read());
+            assertEquals('ह', (char) r.read());
+            assertEquals('€', (char) r.read());
+            assertEquals('한', (char) r.read());
+            assertEquals('薠', (char) r.read());
+            assertEquals(-1, r.read());
+            System.out.println((char) 0x10348);
+        }
+    }
+
+    private static Utf8InputStreamReader reader(String s) {
+        return new Utf8InputStreamReader(new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)));
+    }
+
+}

--- a/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
+++ b/src/test/java/org/subethamail/smtp/internal/io/Utf8InputStreamReaderTest.java
@@ -1,9 +1,11 @@
 package org.subethamail.smtp.internal.io;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.subethamail.smtp.internal.io.Utf8InputStreamReader.numBytes;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -15,7 +17,7 @@ public class Utf8InputStreamReaderTest {
     @Test
     public void test() throws IOException {
         final char[] chars = Character.toChars(0x1F701);
-        assertEquals(2, chars.length); 
+        assertEquals(2, chars.length);
         final String str = new String(chars);
         String s = "$£Иह€한薠" + str;
         try (Reader r = reader(s)) {
@@ -33,7 +35,7 @@ public class Utf8InputStreamReaderTest {
             assertEquals(-1, r.read());
         }
     }
-    
+
     @Test
     public void testReadIntoArray() throws IOException {
         final char[] chars = Character.toChars(0x1F701);
@@ -42,12 +44,56 @@ public class Utf8InputStreamReaderTest {
         try (Reader r = reader(s)) {
             char[] chrs = new char[1000];
             int n = r.read(chrs, 0, 2);
-            n+= r.read(chrs, 2, 1000);
+            n += r.read(chrs, 2, 1000);
             assertEquals(9, n);
             assertEquals(-1, r.read(chrs));
         }
     }
-    
+
+    @Test
+    public void testEarlyEof() throws IOException {
+        byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
+        byte[] b = new byte[] { bytes[0] };
+        try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
+            assertThrows(EOFException.class, () -> r.read());
+        }
+    }
+
+    @Test
+    public void testNotContinuation() throws IOException {
+        byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
+        byte[] b = new byte[] { bytes[0], bytes[0] };
+        try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
+            assertThrows(IllegalStateException.class, () -> r.read());
+        }
+    }
+
+    @Test
+    public void testNotContinuation2() throws IOException {
+        byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
+        byte[] b = new byte[] { bytes[0], '$' };
+        try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
+            assertThrows(IllegalStateException.class, () -> r.read());
+        }
+    }
+
+    @Test
+    public void testContinuationByteCannotBeFirstByte() throws IOException {
+        byte[] bytes = "£".getBytes(StandardCharsets.UTF_8);
+        byte[] b = new byte[] { bytes[1] };
+        try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
+            assertThrows(IllegalStateException.class, () -> r.read());
+        }
+    }
+
+    @Test
+    public void testUtf8ByteHasTooManyLeadingOnes() throws IOException {
+        byte[] b = new byte[] { (byte) 248 };
+        try (Reader r = new Utf8InputStreamReader(new ByteArrayInputStream(b))) {
+            assertThrows(IllegalStateException.class, () -> r.read());
+        }
+    }
+
     @Test
     public void testNumBytes() {
         assertEquals(1, numBytes('$'));

--- a/src/test/java/org/subethamail/smtp/server/MessageHandlerTest.java
+++ b/src/test/java/org/subethamail/smtp/server/MessageHandlerTest.java
@@ -39,7 +39,7 @@ public class MessageHandlerTest {
         try {
             SmartClient client = SmartClient.createAndConnect("localhost", server.getPort(), "localhost");
             client.from("john@example.com");
-            client.to("jane@example.com");
+            client.to("eñe@example.com");
             client.dataStart();
             client.dataWrite(TextUtils.getAsciiBytes("body"), 4);
             client.dataEnd();
@@ -50,7 +50,7 @@ public class MessageHandlerTest {
         InOrder o = Mockito.inOrder(f, h);
         o.verify(f).create(ArgumentMatchers.any(MessageContext.class));
         o.verify(h).from("john@example.com");
-        o.verify(h).recipient("jane@example.com");
+        o.verify(h).recipient("eñe@example.com");
         o.verify(h).data(ArgumentMatchers.any(InputStream.class));
         o.verify(h).done();
         Mockito.verifyNoMoreInteractions(f, h);

--- a/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
+++ b/src/test/java/org/subethamail/smtp/util/EmailUtilsTest.java
@@ -24,6 +24,11 @@ public class EmailUtilsTest {
     public void testBlankAddressIsValid() {
         Assert.assertTrue(EmailUtils.isValidEmailAddress("", true));
     }
+    
+    @Test
+    public void testSpecialUtf8CharacterIsInvalidInEmailAddress() {
+        Assert.assertTrue(EmailUtils.isValidEmailAddress("ñ@abc.com", true));
+    }
 
     @Test
     public void testExtract() {


### PR DESCRIPTION
See #132

This PR includes *always-on* support for STMPUTF8. To make it happen a new class `Utf8InputStreamReader` was created for UTF-8 that doesn't buffer unnecessarily (`java.io.InputStreamReader` buffers extra for performance reasons which is a problem for us because command have different uses of the underlying `InputStream` and we can't lose bytes between commands). The new Reader has full test coverage (for what that's worth).