### PR TITLE
Move buffer from Data command to wrap socket.getInputStream

### DIFF
--- a/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
+++ b/src/main/java/org/subethamail/smtp/internal/command/DataCommand.java
@@ -1,6 +1,5 @@
 package org.subethamail.smtp.internal.command;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
@@ -21,7 +20,6 @@ import org.subethamail.smtp.server.Session;
  * @author Jeff Schnitzer
  */
 public final class DataCommand extends BaseCommand {
-    private final static int BUFFER_SIZE = 1024 * 32; // 32k seems reasonable
 
     public DataCommand() {
         super("DATA", "Following text is collected as the message.\n"
@@ -42,7 +40,6 @@ public final class DataCommand extends BaseCommand {
         sess.sendResponse("354 End data with <CR><LF>.<CR><LF>");
 
         InputStream stream = sess.getRawInput();
-        stream = new BufferedInputStream(stream, BUFFER_SIZE);
         stream = new DotTerminatedInputStream(stream);
         stream = new DotUnstuffingInputStream(stream);
         SMTPServer server = sess.getServer();

--- a/src/main/java/org/subethamail/smtp/internal/io/ReceivedHeaderStream.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/ReceivedHeaderStream.java
@@ -8,9 +8,8 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -22,6 +21,9 @@ import com.github.davidmoten.guavamini.Preconditions;
  * Prepends a Received: header at the beginning of the input stream.
  */
 public final class ReceivedHeaderStream extends FilterInputStream {
+    
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z (z)", Locale.US);
+    
     ByteArrayInputStream header;
 
     /**
@@ -56,8 +58,8 @@ public final class ReceivedHeaderStream extends FilterInputStream {
         Preconditions.checkNotNull(heloHost);
         Preconditions.checkNotNull(softwareName);
         Preconditions.checkNotNull(singleRecipient);
-        DateFormat fmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z (z)", Locale.US);
-        String timestamp = fmt.format(new Date());
+        
+        String timestamp = DATE_TIME_FORMATTER.format(ZonedDateTime.now());
 
         StringBuilder header = new StringBuilder();
         header.append("Received: from ").append(heloHost.orElse(null)).append(" (").append(constructTcpInfo(host)).append(")\r\n");
@@ -161,4 +163,5 @@ public final class ReceivedHeaderStream extends FilterInputStream {
     public long skip(long n) throws IOException {
         throw new UnsupportedOperationException();
     }
+    
 }

--- a/src/main/java/org/subethamail/smtp/internal/io/ReceivedHeaderStream.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/ReceivedHeaderStream.java
@@ -8,8 +8,9 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -21,9 +22,6 @@ import com.github.davidmoten.guavamini.Preconditions;
  * Prepends a Received: header at the beginning of the input stream.
  */
 public final class ReceivedHeaderStream extends FilterInputStream {
-    
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z (z)", Locale.US);
-    
     ByteArrayInputStream header;
 
     /**
@@ -58,8 +56,8 @@ public final class ReceivedHeaderStream extends FilterInputStream {
         Preconditions.checkNotNull(heloHost);
         Preconditions.checkNotNull(softwareName);
         Preconditions.checkNotNull(singleRecipient);
-        
-        String timestamp = DATE_TIME_FORMATTER.format(ZonedDateTime.now());
+        DateFormat fmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z (z)", Locale.US);
+        String timestamp = fmt.format(new Date());
 
         StringBuilder header = new StringBuilder();
         header.append("Received: from ").append(heloHost.orElse(null)).append(" (").append(constructTcpInfo(host)).append(")\r\n");
@@ -163,5 +161,4 @@ public final class ReceivedHeaderStream extends FilterInputStream {
     public long skip(long n) throws IOException {
         throw new UnsupportedOperationException();
     }
-    
 }

--- a/src/main/java/org/subethamail/smtp/server/Session.java
+++ b/src/main/java/org/subethamail/smtp/server/Session.java
@@ -1,5 +1,6 @@
 package org.subethamail.smtp.server;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,6 +37,8 @@ import org.subethamail.smtp.server.SessionHandler.SessionAcceptance;
  * @author Jeff Schnitzer
  */
 public final class Session implements Runnable, MessageContext {
+    private static final int BUFFER_SIZE = 8192;
+
     private final static Logger log = LoggerFactory.getLogger(Session.class);
 
     /** A link to our parent server */
@@ -313,7 +316,7 @@ public final class Session implements Runnable, MessageContext {
      */
     public void setSocket(Socket socket) throws IOException {
         this.socket = socket;
-        this.input = this.socket.getInputStream();
+        this.input = new BufferedInputStream(this.socket.getInputStream(), BUFFER_SIZE);
         this.reader = new CRLFTerminatedReader(this.input);
         this.output = this.socket.getOutputStream();
         this.writer = new PrintWriter(this.output);

--- a/src/test/java/org/subethamail/smtp/server/LoadTest.java
+++ b/src/test/java/org/subethamail/smtp/server/LoadTest.java
@@ -20,7 +20,7 @@ import jakarta.mail.internet.MimeMultipart;
 
 public class LoadTest {
 
-    private final static int messages = 200000;
+    private final static int messages = 5000000;
     private final static int port = 1234;
 
     public static final class Server {
@@ -42,14 +42,14 @@ public class LoadTest {
             latch.await();
             server.stop(); // wait for the server to catch up
 
-            System.out
-                    .println(1000.0 * messages * messages / (messages - 1) / (System.currentTimeMillis() - startTime[0])
-                            + " messages/s");
+            long t = (System.currentTimeMillis() - startTime[0]);
+            System.out.println(1000.0 * messages * messages / (messages - 1) / t + " messages/s");
+            System.out.println("total time = " + t/1000 + "s");
         }
     }
 
     public static final class Client {
-        
+
         public static void main(String[] args) throws MessagingException, InterruptedException {
             String to = "you@yours.com";
             String from = "me@mine.com";


### PR DESCRIPTION
As raised in #116, we can improve perf by moving read buffering to wrap the socket input stream.

Load testing in LoadTest.java showed an improved throughput of about 10%.