### PR TITLE
Make Utf8InputStreamReader DECODER non-static

### DIFF
--- a/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
+++ b/src/main/java/org/subethamail/smtp/internal/io/Utf8InputStreamReader.java
@@ -18,7 +18,7 @@ import java.nio.charset.StandardCharsets;
  */
 public final class Utf8InputStreamReader extends Reader {
 
-    private static final CharsetDecoder DECODER = StandardCharsets.UTF_8.newDecoder();
+    private final CharsetDecoder DECODER = StandardCharsets.UTF_8.newDecoder();
 
     private final InputStream in;
     private final ByteBuffer bb = ByteBuffer.allocate(4);


### PR DESCRIPTION
The UTF-8 CharsetDecoder used in Utf8InputStreamReader is stateful during the decoding.

This PR just aims at scoping this possible issue to the already not thread safe reader.