### PR TITLE
Add support to SmartClient for STARTTLS and TLS handshakes to SMTPClient.

### DIFF
--- a/src/main/java/org/subethamail/smtp/client/SMTPClient.java
+++ b/src/main/java/org/subethamail/smtp/client/SMTPClient.java
@@ -11,6 +11,8 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +47,8 @@ public class SMTPClient implements AutoCloseable {
     private final Optional<SocketAddress> bindpoint;
 
     private volatile SocketAddress localSocketAddress;
+
+    private final SSLSocketFactory sslSocketFactory;
 
     /**
      * True if the client has been successfully connected to the server and not
@@ -128,9 +132,29 @@ public class SMTPClient implements AutoCloseable {
      *            were passed to the connect method.
      */
     public SMTPClient(Optional<SocketAddress> bindpoint, Optional<String> hostPortName) {
+        this(bindpoint, hostPortName, Optional.empty());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param bindpoint
+     *            the local socket address. If empty, the system will pick up an
+     *            ephemeral port and a valid local address.
+     * @param hostPortName
+     *            Sets the name of the remote MTA for informative purposes.
+     *            Default is host:port, where host and port are the values which
+     *            were used to open the TCP connection to the server, as they
+     *            were passed to the connect method.
+     * @param sslSocketFactory
+     *            Configures the SSLSocketFactory to use when upgrading a connection to use SSL.
+     *            Defaults to the system SSLSocketFactory if unspecified.
+     */
+    public SMTPClient(Optional<SocketAddress> bindpoint, Optional<String> hostPortName, Optional<SSLSocketFactory> sslSocketFactory) {
         Preconditions.checkNotNull(bindpoint, "bindpoint cannot be null");
         this.bindpoint = bindpoint;
         this.hostPortName = hostPortName;
+        this.sslSocketFactory = sslSocketFactory.orElseGet(() -> (SSLSocketFactory) SSLSocketFactory.getDefault());
     }
 
     public static SMTPClient createAndConnect(String host, int port)
@@ -162,6 +186,20 @@ public class SMTPClient implements AutoCloseable {
         this.socket.bind(this.bindpoint.orElse(null));
         this.socket.setSoTimeout(REPLY_TIMEOUT);
         this.socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT);
+        updateSocket(this.socket);
+        connected = true;
+    }
+
+    /**
+     * Replaces the existing socket with a new Socket, updating the readers, writers and streams derived
+     * from the socket.  Used on the initial connect() to set up IO, and on upgrading a connection to TLS,
+     * where the new Socket is an SSLSocket.
+     *
+     * @param socket
+     * @throws IOException
+     */
+    protected void updateSocket(Socket socket) throws IOException {
+        this.socket = socket;
 
         try {
             this.localSocketAddress = this.socket.getLocalSocketAddress();
@@ -177,8 +215,6 @@ public class SMTPClient implements AutoCloseable {
             close();
             throw e;
         }
-
-        connected = true;
     }
 
     /**
@@ -330,4 +366,20 @@ public class SMTPClient implements AutoCloseable {
         return this.hostPortName.orElse(null);
     }
 
+    /**
+     * Upgrades the existing socket to use an SSL connection in client mode.
+     * @throws IOException
+     */
+    protected void performSSLHandshake() throws IOException {
+        InetSocketAddress remoteAddress = (InetSocketAddress) socket.getRemoteSocketAddress();
+        if(remoteAddress == null){
+            throw new IllegalStateException("socket should be connected at this point");
+        }
+
+        SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket(socket, remoteAddress.getHostName(), socket.getPort(), true);
+        sslSocket.setUseClientMode(true);
+        sslSocket.startHandshake();
+
+        updateSocket(sslSocket);
+    }
 }

--- a/src/main/java/org/subethamail/smtp/client/SmartClient.java
+++ b/src/main/java/org/subethamail/smtp/client/SmartClient.java
@@ -3,6 +3,7 @@ package org.subethamail.smtp.client;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +18,9 @@ import org.subethamail.smtp.client.SMTPClient.Response;
 
 import com.github.davidmoten.guavamini.Preconditions;
 import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * A somewhat smarter abstraction of an SMTP client which doesn't require
@@ -69,9 +73,13 @@ public class SmartClient {
      *            the Authenticator object which will be called after the EHLO
      *            command to authenticate this client to the server. If is null
      *            then no authentication will happen.
+     * @param sslSocketFactory
+     *            the SSLSocketFactory used to create a new SSLSocket when
+     *            startTLS() is called on the client.  If empty, the default
+     *            SSLSocketFactory will be used.
      */
-    private SmartClient(Optional<SocketAddress> bindpoint, String clientHeloHost, Optional<Authenticator> authenticator) {
-        this(new SMTPClient(Preconditions.checkNotNull(bindpoint, "bindpoint cannot be null"), Optional.empty()),
+    private SmartClient(Optional<SocketAddress> bindpoint, String clientHeloHost, Optional<Authenticator> authenticator, Optional<SSLSocketFactory> sslSocketFactory) {
+        this(new SMTPClient(Preconditions.checkNotNull(bindpoint, "bindpoint cannot be null"), Optional.empty(), sslSocketFactory),
                 clientHeloHost, authenticator);
     }
 
@@ -103,7 +111,11 @@ public class SmartClient {
     public final static SmartClient createAndConnect(String host, int port, Optional<SocketAddress> bindpoint,
             String clientHeloHost, Optional<Authenticator> authenticator)
                     throws UnknownHostException, SMTPException, IOException {
-        SmartClient client = new SmartClient(bindpoint, clientHeloHost, authenticator);
+        return createAndConnect(host, port, bindpoint, clientHeloHost, authenticator, Optional.empty());
+    }
+
+    public final static SmartClient createAndConnect(String host, int port, Optional<SocketAddress> bindpoint, String clientHeloHost, Optional<Authenticator> authenticator, Optional<SSLSocketFactory> sslSocketFactory) throws UnknownHostException, SMTPException, IOException {
+        SmartClient client = new SmartClient(bindpoint, clientHeloHost, authenticator, sslSocketFactory);
         client.connect(host, port);
         return client;
     }
@@ -137,16 +149,32 @@ public class SmartClient {
      */
     protected void sendHeloOrEhlo() throws IOException, SMTPException {
         extensions.clear();
-        Response resp = client.sendReceive("EHLO " + heloHost);
-        if (resp.isSuccess()) {
-            parseEhloResponse(resp);
-        } else if (resp.getCode() == 500 || resp.getCode() == 502) {
-            // server does not support EHLO, try HELO
-            client.sendAndCheck("HELO " + heloHost);
-        } else {
-            // some serious error
-            throw new SMTPException(resp);
+        Response resp = sendEhlo();
+        if (!resp.isSuccess()) {
+            if (resp.getCode() == 500 || resp.getCode() == 502) {
+                // server does not support EHLO, try HELO
+                client.sendAndCheck("HELO " + heloHost);
+            } else {
+                // some serious error
+                throw new SMTPException(resp);
+            }
         }
+    }
+
+    /**
+     * Sends the EHLO command, saving the list of SMTP extensions supported by
+     * the server on success.
+     *
+     * @return The EHLO response.
+     * @throws IOException
+     */
+    protected Response sendEhlo() throws IOException {
+        Response resp = client.sendReceive("EHLO " + heloHost);
+        if(resp.isSuccess()) {
+            parseEhloResponse(resp);
+        }
+
+        return resp;
     }
 
     /**
@@ -176,6 +204,28 @@ public class SmartClient {
             serverClosingTransmissionChannel = true;
         return response;
     }
+
+    /**
+     * Upgrades the connection to use TLS with the STARTTLS command and reissues the EHLO to the server.
+     *
+     * @throws IllegalStateException Thrown if a server did not indicate it supports STARTTLS in the original EHLO/HELO.
+     * @throws IOException
+     * @throws SMTPException
+     */
+    public void startTLS() throws IOException, SMTPException {
+        if(!extensions.containsKey("STARTTLS")){
+            throw new IllegalStateException("called STARTTLS on a server that did not advertise STARTTLS support in the EHLO/HELO response");
+        }
+        client.sendAndCheck("STARTTLS");
+
+        this.client.performSSLHandshake();
+        extensions.clear();
+        Response resp = sendEhlo();
+        if (!resp.isSuccess()) {
+            throw new SMTPException(resp);
+        }
+    }
+
 
     public void from(String from) throws IOException, SMTPException {
         client.sendAndCheck("MAIL FROM: <" + from + ">");

--- a/src/test/java/org/subethamail/smtp/TestUtil.java
+++ b/src/test/java/org/subethamail/smtp/TestUtil.java
@@ -33,7 +33,7 @@ import org.subethamail.util.ExtendedTrustManager;
 
 import org.eclipse.angus.mail.util.MailSSLSocketFactory;
 
-class TestUtil {
+public class TestUtil {
 
     private static final String PASSWORD = "password";
 
@@ -42,21 +42,21 @@ class TestUtil {
     static final String EMAIL_FROM = "fred@gmail.com";
     static final int PORT = 25000;
 
-    static SSLContext createTlsSslContext(KeyManager[] keyManagers, TrustManager[] trustManagers)
+    public static SSLContext createTlsSslContext(KeyManager[] keyManagers, TrustManager[] trustManagers)
             throws NoSuchAlgorithmException, KeyManagementException {
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(keyManagers, trustManagers, new java.security.SecureRandom());
         return sslContext;
     }
 
-    static TrustManager[] getTrustManagers() {
+    public static TrustManager[] getTrustManagers() {
         InputStream trustStore = StartTLSFullTest.class.getResourceAsStream("/trustStore.jks");
         TrustManager trustManager = new ExtendedTrustManager(trustStore, PASSWORD.toCharArray(), false);
         TrustManager[] trustManagers = new TrustManager[] { trustManager };
         return trustManagers;
     }
 
-    static KeyManager[] getKeyManagers() throws KeyStoreException, IOException, NoSuchAlgorithmException,
+    public static KeyManager[] getKeyManagers() throws KeyStoreException, IOException, NoSuchAlgorithmException,
             CertificateException, UnrecoverableKeyException {
         InputStream keyStore = StartTLSFullTest.class.getResourceAsStream("/keyStore.jks");
         KeyStore ks = KeyStore.getInstance("JKS");

--- a/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
+++ b/src/test/java/org/subethamail/smtp/client/SmartClientTest.java
@@ -1,12 +1,23 @@
 package org.subethamail.smtp.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.subethamail.smtp.TestUtil.createTlsSslContext;
+import static org.subethamail.smtp.TestUtil.getKeyManagers;
+import static org.subethamail.smtp.TestUtil.getTrustManagers;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.UnknownHostException;
+import java.security.KeyStoreException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Optional;
 import java.util.Set;
+import javax.net.ssl.SSLContext;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,7 +48,42 @@ public class SmartClientTest {
         } finally {
             server.stop();
         }
+    }
 
+    @Test
+    public void testStartTLS() throws SMTPException, IOException , KeyStoreException, KeyManagementException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException {
+        SSLContext sslContext = createTlsSslContext(getKeyManagers(), getTrustManagers());
+
+        SMTPServer server = SMTPServer.port(25000)
+                .enableTLS(true)
+                .startTlsSocketFactory(sslContext)
+                .messageHandlerFactory(createMessageHandlerFactory())
+                .build();
+        try {
+            server.start();
+            SmartClient client = SmartClient.createAndConnect("localhost",
+                    25000,
+                    Optional.empty(),
+                    "clientHeloHost",
+                    Optional.empty(),
+                    Optional.of(sslContext.getSocketFactory())
+            );
+
+            assertEquals("clientHeloHost", client.getHeloHost());
+            assertEquals(0, client.getRecipientCount());
+            assertFalse(client.getAuthenticator().isPresent());
+            assertEquals(5, client.getExtensions().size());
+            Set<String> set = client.getExtensions().keySet();
+            assertTrue(set.contains("8BITMIME"));
+            assertTrue(set.contains("CHUNKING"));
+            assertTrue(set.contains("SMTPUTF8"));
+            assertTrue(set.contains("STARTTLS"));
+
+            client.startTLS();
+            assertEquals(5, client.getExtensions().size());
+        } finally {
+            server.stop();
+        }
     }
 
     private MessageHandlerFactory createMessageHandlerFactory() {


### PR DESCRIPTION
This patch builds upon the work to add STARTTLS support that originally targeted the SMTPServer, adding support to the SMTPClient and SmartClient.  